### PR TITLE
Add model_size option to small_config.json

### DIFF
--- a/pretrain/config/small_config.json
+++ b/pretrain/config/small_config.json
@@ -10,5 +10,6 @@
   "learning_rate": 5e-4,
   "max_seq_length": 512,
   "do_lower_case": false,
-  "generator_hidden_size": 1.0
+  "generator_hidden_size": 1.0,
+  "model_size": "small"
 }


### PR DESCRIPTION
- model_size 옵션이 추가되어있어야 학습시 모델 Output size가 맞게 됨 (없으면 그냥 base가 기본값)