### PR TITLE
chores: sort items in numerical order

### DIFF
--- a/finetune/run_ner.py
+++ b/finetune/run_ner.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import glob
+import re
 
 import numpy as np
 import torch
@@ -272,9 +273,9 @@ def main(cli_args):
 
     results = {}
     if args.do_eval:
-        checkpoints = list(
-            os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True))
-        )
+        checkpoints = list(os.path.dirname(c) for c in
+                           sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
+                                  key=lambda path_with_step: list(map(int, re.findall(r"\d+", path_with_step)))[-1]))
         if not args.eval_all_checkpoints:
             checkpoints = checkpoints[-1:]
         else:
@@ -291,7 +292,8 @@ def main(cli_args):
 
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
-            for key in sorted(results.keys()):
+            for key in sorted(results.keys(),
+                              key=lambda key_with_step: list(map(int, re.findall(r"\d+", key_with_step)))[-1]):
                 f_w.write("{} = {}\n".format(key, str(results[key])))
 
 

--- a/finetune/run_seq_cls.py
+++ b/finetune/run_seq_cls.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import glob
+import re
 
 import numpy as np
 import torch
@@ -258,9 +259,9 @@ def main(cli_args):
 
     results = {}
     if args.do_eval:
-        checkpoints = list(
-            os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True))
-        )
+        checkpoints = list(os.path.dirname(c) for c in
+                           sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
+                                  key=lambda path_with_step: list(map(int, re.findall(r"\d+", path_with_step)))[-1]))
         if not args.eval_all_checkpoints:
             checkpoints = checkpoints[-1:]
         else:
@@ -277,7 +278,8 @@ def main(cli_args):
 
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
-            for key in sorted(results.keys()):
+            for key in sorted(results.keys(),
+                              key=lambda key_with_step: list(map(int, re.findall(r"\d+", key_with_step)))[-1]):
                 f_w.write("{} = {}\n".format(key, str(results[key])))
 
 

--- a/finetune/run_squad.py
+++ b/finetune/run_squad.py
@@ -21,6 +21,7 @@ import glob
 import logging
 import os
 import random
+import re
 import timeit
 
 import numpy as np
@@ -439,7 +440,8 @@ def main(cli_args):
     if args.do_eval:
         checkpoints = list(
             os.path.dirname(c)
-            for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True))
+            for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
+                            key=lambda path_with_steps: list(map(int, re.findall(r"\d+", path_with_steps)))[-1])
         )
         if not args.eval_all_checkpoints:
             checkpoints = checkpoints[-1:]
@@ -460,7 +462,8 @@ def main(cli_args):
 
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
-            for key in sorted(results.keys()):
+            for key in sorted(results.keys(),
+                              key=lambda key_with_steps: list(map(int, re.findall(r"\d+", key_with_steps)))[-1]):
                 f_w.write("{} = {}\n".format(key, str(results[key])))
 
 

--- a/finetune/run_squad.py
+++ b/finetune/run_squad.py
@@ -441,7 +441,7 @@ def main(cli_args):
         checkpoints = list(
             os.path.dirname(c)
             for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
-                            key=lambda path_with_steps: list(map(int, re.findall(r"\d+", path_with_steps)))[-1])
+                            key=lambda path_with_step: list(map(int, re.findall(r"\d+", path_with_step)))[-1])
         )
         if not args.eval_all_checkpoints:
             checkpoints = checkpoints[-1:]
@@ -463,7 +463,7 @@ def main(cli_args):
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
             for key in sorted(results.keys(),
-                              key=lambda key_with_steps: list(map(int, re.findall(r"\d+", key_with_steps)))[-1]):
+                              key=lambda key_with_step: list(map(int, re.findall(r"\d+", key_with_step)))[-1]):
                 f_w.write("{} = {}\n".format(key, str(results[key])))
 
 

--- a/finetune/run_squad.py
+++ b/finetune/run_squad.py
@@ -438,11 +438,9 @@ def main(cli_args):
     # Evaluation - we can ask to evaluate all the checkpoints (sub-directories) in a directory
     results = {}
     if args.do_eval:
-        checkpoints = list(
-            os.path.dirname(c)
-            for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
-                            key=lambda path_with_step: list(map(int, re.findall(r"\d+", path_with_step)))[-1])
-        )
+        checkpoints = list(os.path.dirname(c) for c in
+                           sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
+                                  key=lambda path_with_step: list(map(int, re.findall(r"\d+", path_with_step)))[-1]))
         if not args.eval_all_checkpoints:
             checkpoints = checkpoints[-1:]
         else:


### PR DESCRIPTION
## Description

The keys which consists of string and trailing integer (i.e. "f1_1", "f1_2", "f1_10000") are not sorted in numerical way such that in case when the arg, `eval_all_checkpoints` is turned off, training script does not give the result of latest checkpoint step. 

Also, `eval_result.txt` shows its results in mixed way, instead of chronological (same as numerical in step-wise aspect) order.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
