### PR TITLE
fix: two-way sorting for PR #33

### DIFF
--- a/finetune/run_ner.py
+++ b/finetune/run_ner.py
@@ -292,9 +292,15 @@ def main(cli_args):
 
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
-            for key in sorted(results.keys(),
-                              key=lambda key_with_step: list(map(int, re.findall(r"\d+", key_with_step)))[-1]):
-                f_w.write("{} = {}\n".format(key, str(results[key])))
+            if len(checkpoints) > 1:
+                for key in sorted(results.keys(), key=lambda key_with_step: (
+                        "".join(re.findall(r'[^_]+_', key_with_step)),
+                        int(re.findall(r"_\d+", key_with_step)[-1][1:])
+                )):
+                    f_w.write("{} = {}\n".format(key, str(results[key])))
+            else:
+                for key in sorted(results.keys()):
+                    f_w.write("{} = {}\n".format(key, str(results[key])))
 
 
 if __name__ == '__main__':

--- a/finetune/run_ner.py
+++ b/finetune/run_ner.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import glob
+import re
 
 import numpy as np
 import torch
@@ -272,9 +273,9 @@ def main(cli_args):
 
     results = {}
     if args.do_eval:
-        checkpoints = list(
-            os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True))
-        )
+        checkpoints = list(os.path.dirname(c) for c in
+                           sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
+                                  key=lambda path_with_step: list(map(int, re.findall(r"\d+", path_with_step)))[-1]))
         if not args.eval_all_checkpoints:
             checkpoints = checkpoints[-1:]
         else:
@@ -291,7 +292,8 @@ def main(cli_args):
 
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
-            for key in sorted(results.keys()):
+            for key in sorted(results.keys(),
+                              key=lambda key_with_step: list(map(int, re.findall(r"\d+", key_with_step)))[-1]):
                 f_w.write("{} = {}\n".format(key, str(results[key])))
 
 

--- a/finetune/run_seq_cls.py
+++ b/finetune/run_seq_cls.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import glob
+import re
 
 import numpy as np
 import torch
@@ -258,9 +259,9 @@ def main(cli_args):
 
     results = {}
     if args.do_eval:
-        checkpoints = list(
-            os.path.dirname(c) for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True))
-        )
+        checkpoints = list(os.path.dirname(c) for c in
+                           sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
+                                  key=lambda path_with_step: list(map(int, re.findall(r"\d+", path_with_step)))[-1]))
         if not args.eval_all_checkpoints:
             checkpoints = checkpoints[-1:]
         else:
@@ -277,7 +278,8 @@ def main(cli_args):
 
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
-            for key in sorted(results.keys()):
+            for key in sorted(results.keys(),
+                              key=lambda key_with_step: list(map(int, re.findall(r"\d+", key_with_step)))[-1]):
                 f_w.write("{} = {}\n".format(key, str(results[key])))
 
 

--- a/finetune/run_seq_cls.py
+++ b/finetune/run_seq_cls.py
@@ -278,9 +278,15 @@ def main(cli_args):
 
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
-            for key in sorted(results.keys(),
-                              key=lambda key_with_step: list(map(int, re.findall(r"\d+", key_with_step)))[-1]):
-                f_w.write("{} = {}\n".format(key, str(results[key])))
+            if len(checkpoints) > 1:
+                for key in sorted(results.keys(), key=lambda key_with_step: (
+                        "".join(re.findall(r'[^_]+_', key_with_step)),
+                        int(re.findall(r"_\d+", key_with_step)[-1][1:])
+                )):
+                    f_w.write("{} = {}\n".format(key, str(results[key])))
+            else:
+                for key in sorted(results.keys()):
+                    f_w.write("{} = {}\n".format(key, str(results[key])))
 
 
 if __name__ == '__main__':

--- a/finetune/run_squad.py
+++ b/finetune/run_squad.py
@@ -21,6 +21,7 @@ import glob
 import logging
 import os
 import random
+import re
 import timeit
 
 import numpy as np
@@ -439,7 +440,8 @@ def main(cli_args):
     if args.do_eval:
         checkpoints = list(
             os.path.dirname(c)
-            for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True))
+            for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
+                            key=lambda path_with_steps: list(map(int, re.findall(r"\d+", path_with_steps)))[-1])
         )
         if not args.eval_all_checkpoints:
             checkpoints = checkpoints[-1:]
@@ -460,7 +462,8 @@ def main(cli_args):
 
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
-            for key in sorted(results.keys()):
+            for key in sorted(results.keys(),
+                              key=lambda key_with_steps: list(map(int, re.findall(r"\d+", key_with_steps)))[-1]):
                 f_w.write("{} = {}\n".format(key, str(results[key])))
 
 

--- a/finetune/run_squad.py
+++ b/finetune/run_squad.py
@@ -460,9 +460,15 @@ def main(cli_args):
 
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
-            for key in sorted(results.keys(),
-                              key=lambda key_with_step: list(map(int, re.findall(r"\d+", key_with_step)))[-1]):
-                f_w.write("{} = {}\n".format(key, str(results[key])))
+            if len(checkpoints) > 1:
+                for key in sorted(results.keys(), key=lambda key_with_step: (
+                    "".join(re.findall(r'[^_]+_', key_with_step)),
+                    int(re.findall(r"_\d+", key_with_step)[-1][1:])
+                )):
+                    f_w.write("{} = {}\n".format(key, str(results[key])))
+            else:
+                for key in sorted(results.keys()):
+                    f_w.write("{} = {}\n".format(key, str(results[key])))
 
 
 if __name__ == "__main__":

--- a/finetune/run_squad.py
+++ b/finetune/run_squad.py
@@ -441,7 +441,7 @@ def main(cli_args):
         checkpoints = list(
             os.path.dirname(c)
             for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
-                            key=lambda path_with_steps: list(map(int, re.findall(r"\d+", path_with_steps)))[-1])
+                            key=lambda path_with_step: list(map(int, re.findall(r"\d+", path_with_step)))[-1])
         )
         if not args.eval_all_checkpoints:
             checkpoints = checkpoints[-1:]
@@ -463,7 +463,7 @@ def main(cli_args):
         output_eval_file = os.path.join(args.output_dir, "eval_results.txt")
         with open(output_eval_file, "w") as f_w:
             for key in sorted(results.keys(),
-                              key=lambda key_with_steps: list(map(int, re.findall(r"\d+", key_with_steps)))[-1]):
+                              key=lambda key_with_step: list(map(int, re.findall(r"\d+", key_with_step)))[-1]):
                 f_w.write("{} = {}\n".format(key, str(results[key])))
 
 

--- a/finetune/run_squad.py
+++ b/finetune/run_squad.py
@@ -438,11 +438,9 @@ def main(cli_args):
     # Evaluation - we can ask to evaluate all the checkpoints (sub-directories) in a directory
     results = {}
     if args.do_eval:
-        checkpoints = list(
-            os.path.dirname(c)
-            for c in sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
-                            key=lambda path_with_step: list(map(int, re.findall(r"\d+", path_with_step)))[-1])
-        )
+        checkpoints = list(os.path.dirname(c) for c in
+                           sorted(glob.glob(args.output_dir + "/**/" + "pytorch_model.bin", recursive=True),
+                                  key=lambda path_with_step: list(map(int, re.findall(r"\d+", path_with_step)))[-1]))
         if not args.eval_all_checkpoints:
             checkpoints = checkpoints[-1:]
         else:


### PR DESCRIPTION
## Description

Previous PR for sorting has an issue with readability since `eval_results.txt` is shown by step-wise, therefore, it is hard to read for each metric. Here I applied two-way sorting:

. 1st: sort by its metric name (excluding the `step` number)
. 2nd: sort by step (same as integer sorting) 

Sorry for bothering you with this patch.

## Related Issue

[PR#33](https://github.com/monologg/KoELECTRA/pull/33)